### PR TITLE
Update WorkerPool.yaml to prevent persistent diff on the scaling_mode field

### DIFF
--- a/mmv1/products/cloudrunv2/WorkerPool.yaml
+++ b/mmv1/products/cloudrunv2/WorkerPool.yaml
@@ -294,6 +294,8 @@ properties:
         type: Enum
         description: |
           The scaling mode for the worker pool. It defaults to MANUAL.
+      computed: true
+      default_value: 'MANUAL'
         enum_values:
           - 'AUTOMATIC'
           - 'MANUAL'

--- a/mmv1/products/cloudrunv2/WorkerPool.yaml
+++ b/mmv1/products/cloudrunv2/WorkerPool.yaml
@@ -294,7 +294,7 @@ properties:
         type: Enum
         description: |
           The scaling mode for the worker pool. It defaults to MANUAL.
-        computed: true
+        optional: true
         default_value: 'MANUAL'
         enum_values:
           - 'AUTOMATIC'

--- a/mmv1/products/cloudrunv2/WorkerPool.yaml
+++ b/mmv1/products/cloudrunv2/WorkerPool.yaml
@@ -294,8 +294,8 @@ properties:
         type: Enum
         description: |
           The scaling mode for the worker pool. It defaults to MANUAL.
-      computed: true
-      default_value: 'MANUAL'
+        computed: true
+        default_value: 'MANUAL'
         enum_values:
           - 'AUTOMATIC'
           - 'MANUAL'


### PR DESCRIPTION
```release-note
BUGFIX: cloudrunv2: fixed a perpetual diff on the `google_cloud_run_v2_worker_pool` resource where `scaling.scaling_mode` would show a change from `"MANUAL"` to `null` even when no changes were made to the configuration. Terraform now correctly recognizes the API's default of `"MANUAL"` for this field when the `scaling` block is present.
```
